### PR TITLE
Fix locationRecordSize in async loads

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -210,7 +210,7 @@ function preload(callback) {
 		lastIP: null,
 		lastLine: 0,
 		locationBuffer: null,
-		locationRecordSize: 32,
+		locationRecordSize: 64,
 		mainBuffer: null,
 		recordSize: 12
 	};


### PR DESCRIPTION
Fixes a bug where async loads are not working due to incorrect record sizes.