### PR TITLE
Update dependency: async from ~0.1.22 to ~1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"updatedb-debug": "node scripts/updatedb.js debug"
 	},
 	"dependencies": {
-		"async": "~0.1.22",
+		"async": "~1.3.0",
 		"colors": "0.6.0-1",
 		"glob": "~3.2.1",
 		"iconv-lite": "~0.4.7",


### PR DESCRIPTION
Fixes error when running in strict mode like`node --use_strict`

Issue: https://github.com/caolan/async/issues/189
Commit: https://github.com/caolan/async/commit/515c7dfe26135a1961ae9d71c5c4563f62c9d7b4

All tests are passing

