### PR TITLE
Avoid trying to read from empty city data files (fixes #83)

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -303,6 +303,12 @@ function preload(callback) {
 			datFile = fs.openSync(dataFiles.cityNames, 'r');
 			datSize = fs.fstatSync(datFile).size;
 
+			if (datSize === 0) {
+				throw {
+					code: 'EMPTY_FILE'
+				};
+			}
+
 			cache4.locationBuffer = new Buffer(datSize);
 			fs.readSync(datFile, cache4.locationBuffer, 0, datSize, 0);
 			fs.closeSync(datFile);
@@ -310,7 +316,7 @@ function preload(callback) {
 			datFile = fs.openSync(dataFiles.city, 'r');
 			datSize = fs.fstatSync(datFile).size;
 		} catch(err) {
-			if (err.code !== 'ENOENT' && err.code !== 'EBADF') {
+			if (err.code !== 'ENOENT' && err.code !== 'EBADF' && err.code !== 'EMPTY_FILE') {
 				throw err;
 			}
 
@@ -407,8 +413,14 @@ function preload6(callback) {
 		try {
 			datFile = fs.openSync(dataFiles.city6, 'r');
 			datSize = fs.fstatSync(datFile).size;
+
+			if (datSize === 0) {
+				throw {
+					code: 'EMPTY_FILE'
+				};
+			}
 		} catch(err) {
-			if (err.code !== 'ENOENT' && err.code !== 'EBADF') {
+			if (err.code !== 'ENOENT' && err.code !== 'EBADF' && err.code !== 'EMPTY_FILE') {
 				throw err;
 			}
 


### PR DESCRIPTION
According to #83 it should be possible to replace the city data files (i.e. `data/geoip-city*.dat`) with empty files to avoid loading any city data. This wasn't working due to the reads from the empty files throwing errors (see https://github.com/nodejs/node-v0.x-archive/issues/5685 for discussion).

The alteration checks the file size before attempting to read, there's no `errno` code for empty file so I made up an `errno`-like code to fit with the surrounding code.

```
     Error: Offset is out of bounds
      at Error (native)
      at Object.fs.readSync (fs.js:603:19)
      at preload (node_modules/geoip-lite/lib/geoip.js:307:7)
      at Object.<anonymous> (node_modules/geoip-lite/lib/geoip.js:480:1)
```

```
     Error: Offset is out of bounds
      at Error (native)
      at Object.fs.readSync (fs.js:603:19)
      at preload (node_modules/geoip-lite/lib/geoip.js:307:7)
      at Object.<anonymous> (node_modules/geoip-lite/lib/geoip.js:480:1)
```