### PR TITLE
Fixed bug regarding null changedFile

### DIFF
--- a/lib/fsWatcher.js
+++ b/lib/fsWatcher.js
@@ -25,6 +25,11 @@ function makeFsWatchFilter(name, directory, filename, cooldownDelay, callback) {
 	//This function is called when there is a change in the data directory
 	//It sets a timer to wait for the change to be completed
 	function onWatchEvent(event, changedFile) {
+		// check to make sure changedFile is not null
+		if (!changedFile) {
+			return;
+		}
+		
 		var filePath = path.join(directory, changedFile);
 
 		if (!filename || filename === changedFile) {


### PR DESCRIPTION
When watching for a data update I encountered an error. fs.watch sent a callback with a null filename. The listener passed the null value to path.join and an exception was thrown.

```
path.js:28
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
    at assertPath (path.js:28:11)
    at Object.join (path.js:501:7)
    at FSWatcher.onWatchEvent (REMOVED\node_modules\geoip-lite\lib\fsWatcher.js:28:23)
    at FSWatcher.emit (events.js:159:13)
    at FSEvent.FSWatcher._handle.onchange (fs.js:1379:12)
```