### PR TITLE
Prevent updatedb script crash on non-200 response code from maxmind.com response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules
 /tmp
 npm-debug.log
+
+# JetBrains IDE project files
+/.idea/

--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -5,6 +5,7 @@
 var user_agent = 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.36 Safari/537.36';
 
 var fs = require('fs');
+var http = require('http');
 var https = require('https');
 var path = require('path');
 var url = require('url');
@@ -160,7 +161,7 @@ function check(database, cb) {
 			var status = response.statusCode;
     
 			if (status !== 200) {
-				console.log('ERROR'.red + ': HTTP Request Failed [%d %s]', status, https.STATUS_CODES[status]);
+				console.log('ERROR'.red + ': HTTP Request Failed [%d %s]', status, http.STATUS_CODES[status]);
 				client.abort();
 				process.exit();
 			}
@@ -221,7 +222,7 @@ function fetch(database, cb) {
 		var status = response.statusCode;
 
 		if (status !== 200) {
-			console.log('ERROR'.red + ': HTTP Request Failed [%d %s]', status, https.STATUS_CODES[status]);
+			console.log('ERROR'.red + ': HTTP Request Failed [%d %s]', status, http.STATUS_CODES[status]);
 			client.abort();
 			process.exit();
 		}


### PR DESCRIPTION
This PR fixes a crash caused by using the https module that doesn't have the status codes instead of http.

```
 Checking  https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.md5
 /code/node_modules/geoip-lite/scripts/updatedb.js:163
                 console.log('ERROR'.red + ': HTTP Request Failed [%d %s]', status, https.STATUS_CODES[status]);
                                                                                                      ^

 TypeError: Cannot read property '503' of undefined
     at ClientRequest.onResponse (/code/node_modules/geoip-lite/scripts/updatedb.js:163:90)
     at Object.onceWrapper (events.js:277:13)
     at ClientRequest.emit (events.js:189:13)
     at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:556:21)
     at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
     at TLSSocket.socketOnData (_http_client.js:442:20)
     at TLSSocket.emit (events.js:189:13)
     at addChunk (_stream_readable.js:284:12)
     at readableAddChunk (_stream_readable.js:265:11)
     at TLSSocket.Readable.push (_stream_readable.js:220:10)
```